### PR TITLE
fix: bumped intl version to allow 0.18.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: bumped intl version to allow 0.18.*
+
 ## 1.1.0
 
 - add: locale and builder to showMonthPicker function

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mat_month_picker_dialog
 description: Material design month picker dialog.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/leoshusar/mat_month_picker_dialog
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: '>=0.17.0 <0.19.0'
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
Changed intl version to range `>=0.17.0 <0.19.0` to allow both 0.17 and 0.18.

fixes #2 